### PR TITLE
Small correction to runprebuild.sh

### DIFF
--- a/runprebuild.sh
+++ b/runprebuild.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ARCH="x86"
 CONFIG="Debug"
 BUILD=false


### PR DESCRIPTION
- Specify bash as the wheel to parse the script otherwise syntax errors
