### PR TITLE
Add configuration option in Meshing.ini to address part of Issue #106 initially reported by Fine

### DIFF
--- a/WhiteCoreSim/Config/Sim/Physics/Meshing.ini
+++ b/WhiteCoreSim/Config/Sim/Physics/Meshing.ini
@@ -13,6 +13,7 @@
     ;; Replace the spaces in the region name with _.
     ;; Region_Region_Name_PhysicsEngine = OpenDynamicsEngine
     ;; Region_Region_Name_MeshingEngine = Meshmerizer
+	;; Region_Region_name_PhysicsEngine = BulletSim
 
     ;; Path to decoded sculpt maps
     ;; Defaults to "j2kDecodeCache


### PR DESCRIPTION
- Adds a configuration option to Meshing.ini to allow Meshmerizer to work with BulletSim
- Fine forgot to add this to Meshing.ini
