### PR TITLE
Fix doxygen.sh to output to the correct directory

### DIFF
--- a/Documentation/doxygen.sh
+++ b/Documentation/doxygen.sh
@@ -1,5 +1,6 @@
+#!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd ${DIR}
+cd $DIR/../
 mkdir -p WhiteCoreSim/WhiteCoreDocs/doxygen
 rm -fr WhiteCoreSim/WhiteCoreDocs/doxygen/*
-doxygen doxygen.conf
+doxygen Documentation/doxygen.conf


### PR DESCRIPTION
Adds a shebang to make it clear how to execute the program
 ${DIR} is the syntax for subshell execution $DIR is the syntax for variable access