### PR TITLE
Fix for issue #137

### DIFF
--- a/WhiteCore/Modules/Caps/RenderMaterials.cs
+++ b/WhiteCore/Modules/Caps/RenderMaterials.cs
@@ -420,7 +420,7 @@ namespace WhiteCore.Modules.Caps
 
             using (MemoryStream msSinkCompressed = new MemoryStream())
             {
-                using (ZOutputStream zOut = new ZOutputStream(msSinkCompressed,1))
+                using (ZOutputStream zOut = new ZOutputStream(msSinkCompressed))
                 {
                     CopyStream(new MemoryStream(OSDParser.SerializeLLSDBinary(inOsd, useHeader)), zOut);
                     msSinkCompressed.Seek(0L, SeekOrigin.Begin);

--- a/WhiteCore/Physics/Meshing/Meshmerizer.cs
+++ b/WhiteCore/Physics/Meshing/Meshmerizer.cs
@@ -273,7 +273,7 @@ namespace WhiteCore.Physics.Meshing
                             {
                                 using (MemoryStream outMs = new MemoryStream())
                                 {
-                                    using (ZOutputStream zOut = new ZOutputStream(outMs,1))
+                                    using (ZOutputStream zOut = new ZOutputStream(outMs))
                                     {
                                         byte[] readBuffer = new byte[2048];
                                         int readLen = 0;


### PR DESCRIPTION
- Does not change zlib.net.dll
- fixes the using (ZOutputStream zOut = new ZOutputStream(outMs,1)) by returning it to its original state of using (ZOutputStream zOut = new ZOutputStream(outMs))
- fixes the using (ZOutputStream zOut = new ZOutputStream(msSinkCompressed,1)) by returning it to its original state of using using (ZOutputStream zOut = new ZOutputStream(msSinkCompressed))

Note these work properly with zlib.net.dll and confirms stormsonweather's comment on this issue