### PR TITLE
Typo Fix in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,7 @@ addon-modules/*/
 WhiteCoreSim/bin/*.log
 WhiteCoreSim/bin/*/WhiteCore.*.dll
 WhiteCoreSim/bin/.version
-WhitecoreSim/bin/WhiteCore.*.dll
+WhiteCoreSim/bin/WhiteCore.*.dll
 WhiteCoreSim/bin/WhiteCore.*.exe
 WhiteCoreSim/bin/WhiteCore.exe
 


### PR DESCRIPTION
Fix it so that .gitignore ignores WhiteCoreSim/bin/WhiteCore.*.dll instead of WhitecoreSim/bin/WhiteCore.*.dll