### PR TITLE
Some general cleanup

### DIFF
--- a/WhiteCore/Framework/SceneInfo/UuidGatherer.cs
+++ b/WhiteCore/Framework/SceneInfo/UuidGatherer.cs
@@ -119,14 +119,14 @@ namespace WhiteCore.Framework.SceneInfo
         /// <param name="scene"></param>
         public void GatherAssetUuids(ISceneEntity sceneObject, IDictionary<UUID, AssetType> assetUuids)
         {
-//            MainConsole.Instance.DebugFormat(
-//                "[ASSET GATHERER]: Getting assets for object {0}, {1}", sceneObject.Name, sceneObject.UUID);
+            //MainConsole.Instance.DebugFormat(
+            //    "[ASSET GATHERER]: Getting assets for object {0}, {1}", sceneObject.Name, sceneObject.UUID);
 
             ISceneChildEntity[] parts = sceneObject.ChildrenEntities().ToArray();
             foreach (ISceneChildEntity part in parts)
             {
-//                MainConsole.Instance.DebugFormat(
-//                    "[ARCHIVER]: Getting part {0}, {1} for object {2}", part.Name, part.UUID, sceneObject.UUID);
+                //MainConsole.Instance.DebugFormat(
+                //    "[Archiver]: Getting part {0}, {1} for object {2}", part.Name, part.UUID, sceneObject.UUID);
 
                 try
                 {
@@ -167,15 +167,14 @@ namespace WhiteCore.Framework.SceneInfo
                 }
                 catch (Exception e)
                 {
-                    MainConsole.Instance.ErrorFormat("[UUID GATHERER]: Failed to get part - {0}", e);
+                    MainConsole.Instance.ErrorFormat("[UUID Gatherer]: Failed to get part - {0}", e);
                     MainConsole.Instance.DebugFormat(
-                        "[UUID GATHERER]: Texture entry length for prim was {0} (min is 46)",
+                        "[UUID Gatherer]: Texture entry length for prim was {0} (min is 46)",
                         part.Shape.TextureEntry.Length);
                 }
             }
         }
-
-        
+   
         /// <summary>
         /// Gather all of the texture asset UUIDs used to reference "Materials" such as normal and specular maps
         /// </summary>
@@ -203,7 +202,7 @@ namespace WhiteCore.Framework.SceneInfo
                                 if (normalMapId != UUID.Zero)
                                 {
                                     assetUuids[normalMapId] = AssetType.Texture;
-                                    //m_log.Info("[UUID Gatherer]: found normal map ID: " + normalMapId.ToString());
+                                    //MainConsole.Instance.Info("[UUID Gatherer]: found normal map ID: " + normalMapId.ToString());
                                 }
                             }
                             if (mat.ContainsKey("SpecMap"))
@@ -212,7 +211,7 @@ namespace WhiteCore.Framework.SceneInfo
                                 if (specularMapId != UUID.Zero)
                                 {
                                     assetUuids[specularMapId] = AssetType.Texture;
-                                    //m_log.Info("[UUID Gatherer]: found specular map ID: " + specularMapId.ToString());
+                                    //MainConsole.Instance.Info("[UUID Gatherer]: found specular map ID: " + specularMapId.ToString());
                                 }
                             }
                         }
@@ -281,13 +280,13 @@ namespace WhiteCore.Framework.SceneInfo
             if (null != scriptAsset)
             {
                 string script = Utils.BytesToString(scriptAsset.Data);
-                //MainConsole.Instance.DebugFormat("[ARCHIVER]: Script {0}", script);
+                //MainConsole.Instance.DebugFormat("[Archiver]: Script {0}", script);
                 MatchCollection uuidMatches = Util.UUIDPattern.Matches(script);
-                //MainConsole.Instance.DebugFormat("[ARCHIVER]: Found {0} matches in script", uuidMatches.Count);
+                //MainConsole.Instance.DebugFormat("[Archiver]: Found {0} matches in script", uuidMatches.Count);
 
                 foreach (UUID uuid in from Match uuidMatch in uuidMatches select new UUID(uuidMatch.Value))
                 {
-                    //MainConsole.Instance.DebugFormat("[ARCHIVER]: Recording {0} in script", uuid);
+                    //MainConsole.Instance.DebugFormat("[Archiver]: Recording {0} in script", uuid);
 
                     // Assume AssetIDs embedded in scripts are textures
                     assetUuids[uuid] = AssetType.Texture;
@@ -311,7 +310,7 @@ namespace WhiteCore.Framework.SceneInfo
                 wearableAsset.Decode();
 
                 //MainConsole.Instance.DebugFormat(
-                //    "[ARCHIVER]: Wearable asset {0} references {1} assets", wearableAssetUuid, wearableAsset.Textures.Count);
+                //    "[Archiver]: Wearable asset {0} references {1} assets", wearableAssetUuid, wearableAsset.Textures.Count);
 
                 foreach (UUID uuid in wearableAsset.Textures.Values)
                 {

--- a/WhiteCore/Framework/Utilities/Constants.cs
+++ b/WhiteCore/Framework/Utilities/Constants.cs
@@ -25,7 +25,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 namespace WhiteCore.Framework.Utilities
 {
     public static class Constants
@@ -45,6 +44,7 @@ namespace WhiteCore.Framework.Utilities
         public const string DEFAULT_AVATARARCHIVE_DIR = "AvatarArchives";
         public const string DEFAULT_OARARCHIVE_DIR = "OarFiles";
         public const string DEFAULT_USERINVENTORY_DIR = "UserArchives";
+        public const string DEFAULT_OAR_BACKUP_FILENAME = "region.oar";
 
         public const string DEFAULT_USERHTML_DIR = "html";
         public const string DEFAULT_LOG_DIR = "logs";
@@ -88,7 +88,6 @@ namespace WhiteCore.Framework.Utilities
         public const string MarketplaceOwnerUUID = "198e72a6-cef6-4bbb-ae08-c0a79e6b7d1e";
         public const string MarketplaceOwnerName = "Marketplace Concierge";
 
-
         // user levels
         public const int USER_DISABLED = -2;
         public const int USER_BANNED = -1;
@@ -120,6 +119,5 @@ namespace WhiteCore.Framework.Utilities
         public const int GROUP_PAYMENTS_DELAY = 30;         // minutes to wait after stipend payments before processing group payments
         public const int GROUP_DISBURSMENTS_DELAY = 5;      // offset disbursments by 5 minutes
         public const int DIRECTORYFEE_GRACE_PERIOD = 2;     // hours grace period before a fee will be charged at least once
-
     }
 }

--- a/WhiteCore/Modules/Archivers/Inventory/InventoryArchiveReadRequest.cs
+++ b/WhiteCore/Modules/Archivers/Inventory/InventoryArchiveReadRequest.cs
@@ -161,7 +161,7 @@ namespace WhiteCore.Modules.Archivers
                     folderCandidates = InventoryArchiveUtils.FindFolderByPath(m_inventoryService, m_userInfo.PrincipalID, m_invPath);
                     if (folderCandidates.Count == 0)
                     {
-                        MainConsole.Instance.ErrorFormat("[INVENTORY ARCHIVER]: Unable to create Inventory path {0}",
+                        MainConsole.Instance.ErrorFormat("[Inventory Archiver]: Unable to create Inventory path {0}",
                                                      m_invPath);
                         return loadedNodes;
                     }
@@ -175,7 +175,7 @@ namespace WhiteCore.Modules.Archivers
                 // resolved
                 Dictionary<string, InventoryFolderBase> resolvedFolders = new Dictionary<string, InventoryFolderBase>();
 
-                MainConsole.Instance.Info("[ARCHIVER]: Commencing load from archive");
+                MainConsole.Instance.Info("[Archiver]: Commencing load from archive");
                 int ticker = 0;
 
                 byte[] data;
@@ -203,7 +203,7 @@ namespace WhiteCore.Modules.Archivers
 
                         if ((successfulAssetRestores)%50 == 0)
                             MainConsole.Instance.InfoFormat(
-                                " [INVENTORY ARCHIVER]: Loaded {0} assets...",
+                                " [Inventory Archiver]: Loaded {0} assets...",
                                 successfulAssetRestores);
                     }
                     else if (filePath.StartsWith(ArchiveConstants.INVENTORY_PATH))
@@ -228,7 +228,7 @@ namespace WhiteCore.Modules.Archivers
 
                                 if ((successfulItemRestores)%50 == 0)
                                     MainConsole.Instance.InfoFormat(
-                                        "[INVENTORY ARCHIVER]: Restored {0} items...",successfulItemRestores);
+                                        "[Inventory Archiver]: Restored {0} items...",successfulItemRestores);
 
                                 // If we aren't loading the folder containing the item then well need to update the 
                                 // viewer separately for that item.
@@ -246,7 +246,7 @@ namespace WhiteCore.Modules.Archivers
                 }
  
                 MainConsole.Instance.CleanInfo("");
-                MainConsole.Instance.Info("[INVENTORY ARCHIVER]: Saving loaded inventory items");
+                MainConsole.Instance.Info("[Inventory Archiver]: Saving loaded inventory items");
                 ticker = 0;
 
                 int successfulItemLoaded = 0;
@@ -261,7 +261,7 @@ namespace WhiteCore.Modules.Archivers
 
                     if ((successfulItemLoaded)%50 == 0)
                         MainConsole.Instance.InfoFormat(
-                            "[INVENTORY ARCHIVER]: Loaded {0} items of {1}...",
+                            "[Inventory Archiver]: Loaded {0} items of {1}...",
                             successfulItemLoaded, itemsSavedOff.Count);
                 }
                 itemsSavedOff.Clear();
@@ -269,9 +269,9 @@ namespace WhiteCore.Modules.Archivers
 
                 MainConsole.Instance.CleanInfo("");
                 MainConsole.Instance.InfoFormat(
-                    "[INVENTORY ARCHIVER]: Successfully loaded {0} assets with {1} failures",
+                    "[Inventory Archiver]: Successfully loaded {0} assets with {1} failures",
                     successfulAssetRestores, failedAssetRestores);
-                MainConsole.Instance.InfoFormat("[INVENTORY ARCHIVER]: Successfully loaded {0} items",
+                MainConsole.Instance.InfoFormat("[Inventory Archiver]: Successfully loaded {0} items",
                                                 successfulItemRestores);
 
                 return loadedNodes;
@@ -309,15 +309,14 @@ namespace WhiteCore.Modules.Archivers
         {
             string iarPathExisting = iarPath;
 
-            //            MainConsole.Instance.DebugFormat(
-            //                "[INVENTORY ARCHIVER]: Loading folder {0} {1}", rootDestFolder.Name, rootDestFolder.ID);
+            //MainConsole.Instance.DebugFormat(
+            //    "[Inventory Archiver]: Loading folder {0} {1}", rootDestFolder.Name, rootDestFolder.ID);
 
             InventoryFolderBase destFolder
                 = ResolveDestinationFolder(rootDestFolder, ref iarPathExisting, ref resolvedFolders);
 
-            //            MainConsole.Instance.DebugFormat(
-            //                "[INVENTORY ARCHIVER]: originalArchivePath [{0}], section already loaded [{1}]", 
-            //                iarPath, iarPathExisting);
+            //MainConsole.Instance.DebugFormat(
+            //    "[Inventory Archiver]: originalArchivePath [{0}], section already loaded [{1}]", iarPath, iarPathExisting);
 
             string iarPathToCreate = iarPath.Substring(iarPathExisting.Length);
             CreateFoldersForPath(destFolder, iarPathExisting, iarPathToCreate, ref resolvedFolders, ref loadedNodes);
@@ -349,16 +348,16 @@ namespace WhiteCore.Modules.Archivers
             ref string archivePath,
             ref Dictionary<string, InventoryFolderBase> resolvedFolders)
         {
-            //            string originalArchivePath = archivePath;
+            //string originalArchivePath = archivePath;
 
             while (archivePath.Length > 0)
             {
-                //                MainConsole.Instance.DebugFormat("[INVENTORY ARCHIVER]: Trying to resolve destination folder {0}", archivePath);
+                //MainConsole.Instance.DebugFormat("[Inventory Archiver]: Trying to resolve destination folder {0}", archivePath);
 
                 if (resolvedFolders.ContainsKey(archivePath))
                 {
-                    //                    MainConsole.Instance.DebugFormat(
-                    //                        "[INVENTORY ARCHIVER]: Found previously created folder from archive path {0}", archivePath);
+                    //MainConsole.Instance.DebugFormat(
+                    //    "[Inventory Archiver]: Found previously created folder from archive path {0}", archivePath);
                     return resolvedFolders[archivePath];
                 }
                 if (m_merge)
@@ -387,9 +386,8 @@ namespace WhiteCore.Modules.Archivers
                 }
                 else
                 {
-                    //                        MainConsole.Instance.DebugFormat(
-                    //                            "[INVENTORY ARCHIVER]: Found no previously created folder for archive path {0}",
-                    //                            originalArchivePath);
+                    //MainConsole.Instance.DebugFormat(
+                    //    "[Inventory Archiver]: Found no previously created folder for archive path {0}", originalArchivePath);
                     archivePath = string.Empty;
                     return rootDestFolder;
                 }
@@ -427,7 +425,7 @@ namespace WhiteCore.Modules.Archivers
 
             for (int i = 0; i < rawDirsToCreate.Length; i++)
             {
-                //                MainConsole.Instance.DebugFormat("[INVENTORY ARCHIVER]: Creating folder {0} from IAR", rawDirsToCreate[i]);
+                //MainConsole.Instance.DebugFormat("[Inventory Archiver]: Creating folder {0} from IAR", rawDirsToCreate[i]);
 
                 if (!rawDirsToCreate[i].Contains(ArchiveConstants.INVENTORY_NODE_NAME_COMPONENT_SEPARATOR))
                     continue;
@@ -472,7 +470,7 @@ namespace WhiteCore.Modules.Archivers
                 // Record that we have now created this folder
                 iarPathExisting += rawDirsToCreate[i] + "/";
 
-                MainConsole.Instance.DebugFormat("[INVENTORY ARCHIVER]: Created folder {0} from IAR", iarPathExisting);
+                MainConsole.Instance.DebugFormat("[Inventory Archiver]: Created folder {0} from IAR", iarPathExisting);
                 resolvedFolders[iarPathExisting] = destFolder;
 
                 if (0 == i && loadedNodes != null)
@@ -488,7 +486,6 @@ namespace WhiteCore.Modules.Archivers
         protected InventoryItemBase LoadItem(byte[] data, InventoryFolderBase loadFolder)
         {
             InventoryItemBase item = UserInventoryItemSerializer.Deserialize(data);
-
 
             UUID ospResolvedId = OspResolver.ResolveOspa(item.CreatorId, m_accountService);
             if (UUID.Zero != ospResolvedId)
@@ -510,8 +507,7 @@ namespace WhiteCore.Modules.Archivers
             // Don't use the item ID that's in the file, this could be a local user's folder
             //item.ID = UUID.Random();
             item.Owner = m_userInfo.PrincipalID;
-
-        
+     
             // Record the creator id for the item's asset so that we can use it later, if necessary, when the asset
             // is loaded.
             // FIXME: This relies on the items coming before the assets in the TAR file.  Need to create stronger
@@ -538,9 +534,8 @@ namespace WhiteCore.Modules.Archivers
 
                 if (f != null)
                 {
-                    //                    MainConsole.Instance.DebugFormat(
-                    //                        "[LOCAL INVENTORY SERVICES CONNECTOR]: Found folder {0} type {1} for item {2}", 
-                    //                        f.Name, (AssetType)f.Type, item.Name);
+                    //MainConsole.Instance.DebugFormat(
+                    //    "[Local Inventory Services Connector]: Found folder {0} type {1} for item {2}", f.Name, (AssetType)f.Type, item.Name);
 
                     item.Folder = f.ID;
                 }
@@ -598,7 +593,7 @@ namespace WhiteCore.Modules.Archivers
             if (i == -1)
             {
                 MainConsole.Instance.ErrorFormat(
-                    "[INVENTORY ARCHIVER]: Could not find extension information in asset path {0} since it's missing the separator {1}.  Skipping",
+                    "[Inventory Archiver]: Could not find extension information in asset path {0} since it's missing the separator {1}.  Skipping",
                     assetPath, ArchiveConstants.ASSET_EXTENSION_SEPARATOR);
 
                 return false;
@@ -614,7 +609,7 @@ namespace WhiteCore.Modules.Archivers
 
                 if (assetType == AssetType.Unknown)
                     MainConsole.Instance.WarnFormat(
-                        "[INVENTORY ARCHIVER]: Importing {0} byte asset {1} with unknown type", data.Length,
+                        "[Inventory Archiver]: Importing {0} byte asset {1} with unknown type", data.Length,
                         uuid);
                 else if (assetType == AssetType.Object)
                 {
@@ -648,7 +643,7 @@ namespace WhiteCore.Modules.Archivers
                                 SceneEntitySerializer.SceneObjectSerializer.ToOriginalXmlFormat(sceneObject));
                     }
                 }
-                //MainConsole.Instance.DebugFormat("[INVENTORY ARCHIVER]: Importing asset {0}, type {1}", uuid, assetType);
+                //MainConsole.Instance.DebugFormat("[Inventory Archiver]: Importing asset {0}, type {1}", uuid, assetType);
 
                 AssetBase asset = new AssetBase(assetID, "From IAR", assetType, m_overridecreator)
                                       {
@@ -666,12 +661,11 @@ namespace WhiteCore.Modules.Archivers
                 return true;
             }
             MainConsole.Instance.ErrorFormat(
-                "[INVENTORY ARCHIVER]: Tried to dearchive data with path {0} with an unknown type extension {1}",
+                "[Inventory Archiver]: Tried to dearchive data with path {0} with an unknown type extension {1}",
                 assetPath, extension);
 
             return false;
         }
-
 
         /// <summary>
         /// Loads the archive.xml control file.
@@ -699,8 +693,7 @@ namespace WhiteCore.Modules.Archivers
                         int minorVersion = int.Parse (xtr.GetAttribute(1));
                         string version = string.Format ("{0}.{1}", majorVersion, minorVersion);
 
-                        MainConsole.Instance.InfoFormat("[INVENTORY ARCHIVER]: Loading version {0} IAR", version);                        
-
+                        MainConsole.Instance.InfoFormat("[Inventory Archiver]: Loading version {0} IAR", version);                        
                     }
                     if (xtr.Name == "assets_included")
                     {
@@ -711,6 +704,5 @@ namespace WhiteCore.Modules.Archivers
                 }
             }
         }
-
     }
 }

--- a/WhiteCore/Modules/Archivers/Inventory/InventoryArchiveWriteRequest.cs
+++ b/WhiteCore/Modules/Archivers/Inventory/InventoryArchiveWriteRequest.cs
@@ -163,7 +163,7 @@ namespace WhiteCore.Modules.Archivers
             {
                 // We're almost done.  Just need to write out the control file now
                 m_archiveWriter.WriteFile(ArchiveConstants.CONTROL_FILE_PATH, CreateControlFile(m_saveAssets));
-                MainConsole.Instance.InfoFormat("[INVENTORY ARCHIVER]: Added control file to archive.");
+                MainConsole.Instance.InfoFormat("[Inventory Archiver]: Added control file to archive.");
                 m_archiveWriter.Close();
             }
             catch (Exception e)
@@ -188,7 +188,7 @@ namespace WhiteCore.Modules.Archivers
             if (!CanUserArchiveObject(m_userInfo.PrincipalID, inventoryItem))
             {
                 MainConsole.Instance.InfoFormat(
-                    "[INVENTORY ARCHIVER]: Insufficient permissions, skipping inventory item {0} {1} at {2}",
+                    "[Inventory Archiver]: Insufficient permissions, skipping inventory item {0} {1} at {2}",
                     inventoryItem.Name, inventoryItem.ID, path);
 
                 // Count Items Excluded
@@ -362,7 +362,7 @@ namespace WhiteCore.Modules.Archivers
                 if (inventoryFolder != null)
                 {
                     MainConsole.Instance.DebugFormat(
-                        "[INVENTORY ARCHIVER]: Found folder {0} {1} at {2}",
+                        "[Inventory Archiver]: Found folder {0} {1} at {2}",
                         inventoryFolder.Name,
                         inventoryFolder.ID,
                         m_invPath == String.Empty ? InventoryFolderImpl.PATH_DELIMITER : m_invPath);
@@ -373,7 +373,7 @@ namespace WhiteCore.Modules.Archivers
                 else if (inventoryItem != null)
                 {
                     MainConsole.Instance.DebugFormat(
-                        "[INVENTORY ARCHIVER]: Found item {0} {1} at {2}",
+                        "[Inventory Archiver]: Found item {0} {1} at {2}",
                         inventoryItem.Name, inventoryItem.ID, m_invPath);
 
                     SaveInvItem(inventoryItem, ArchiveConstants.INVENTORY_PATH);
@@ -399,7 +399,7 @@ namespace WhiteCore.Modules.Archivers
             }
             else
             {
-                MainConsole.Instance.Debug("[INVENTORY ARCHIVER]: Save Complete");
+                MainConsole.Instance.Debug("[Inventory Archiver]: Save Complete");
                 m_archiveWriter.Close();
             }
         }
@@ -409,7 +409,7 @@ namespace WhiteCore.Modules.Archivers
         /// </summary>
         protected void SaveUsers()
         {
-            MainConsole.Instance.InfoFormat("[INVENTORY ARCHIVER]: Saving user information for {0} users",
+            MainConsole.Instance.InfoFormat("[Inventory Archiver]: Saving user information for {0} users",
                                             m_userUuids.Count);
 
             foreach (UUID creatorId in m_userUuids.Keys)
@@ -425,7 +425,7 @@ namespace WhiteCore.Modules.Archivers
                 }
                 else
                 {
-                    MainConsole.Instance.WarnFormat("[INVENTORY ARCHIVER]: Failed to get creator profile for {0}",
+                    MainConsole.Instance.WarnFormat("[Inventory Archiver]: Failed to get creator profile for {0}",
                                                     creatorId);
                 }
             }

--- a/WhiteCore/Modules/Archivers/Inventory/InventoryArchiverModule.cs
+++ b/WhiteCore/Modules/Archivers/Inventory/InventoryArchiverModule.cs
@@ -116,7 +116,7 @@ namespace WhiteCore.Modules.Archivers
                 catch (EntryPointNotFoundException e)
                 {
                     MainConsole.Instance.ErrorFormat(
-                        "[ARCHIVER]: Mismatch between Mono and zlib1g library version when trying to create compression stream."
+                        "[Archiver]: Mismatch between Mono and zlib1g library version when trying to create compression stream."
                         + "If you've manually installed Mono, have you appropriately updated zlib1g as well?");
                     MainConsole.Instance.Error(e);
 
@@ -191,10 +191,8 @@ namespace WhiteCore.Modules.Archivers
                         + "--perm=<permissions> : If present, verify asset permissions before saving.\n"
                         + "   <permissions> can include 'C' (Copy), 'M' (Modify, 'T' (Transfer)",
                         HandleSaveIARConsoleCommand, false, true);
-
                 }
             }
-
         }
 
         #endregion
@@ -244,7 +242,7 @@ namespace WhiteCore.Modules.Archivers
                 catch (EntryPointNotFoundException e)
                 {
                     MainConsole.Instance.ErrorFormat(
-                        "[ARCHIVER]: Mismatch between Mono and zlib1g library version when trying to create compression stream.\n"
+                        "[Archiver]: Mismatch between Mono and zlib1g library version when trying to create compression stream.\n"
                         + "If you've manually installed Mono, have you appropriately updated zlib1g as well?");
                     MainConsole.Instance.Error(e);
 
@@ -276,7 +274,7 @@ namespace WhiteCore.Modules.Archivers
                 catch (EntryPointNotFoundException e)
                 {
                     MainConsole.Instance.ErrorFormat(
-                        "[ARCHIVER]: Mismatch between Mono and zlib1g library version when trying to create compression stream.\n"
+                        "[Archiver]: Mismatch between Mono and zlib1g library version when trying to create compression stream.\n"
                         + "If you've manually installed Mono, have you appropriately updated zlib1g as well?");
                     MainConsole.Instance.Error(e);
 
@@ -478,7 +476,6 @@ namespace WhiteCore.Modules.Archivers
                     lastName = newParams[3];
                 }
 
-
                 // optional...
                 string iarPath = "/*";
                 if (newParams.Count > 5)
@@ -493,7 +490,6 @@ namespace WhiteCore.Modules.Archivers
                 } else
                     archiveFileName = newParams[4];
                 
-
                 //some file sanity checks
                 string savePath;
                 savePath = PathHelpers.VerifyWriteFile (archiveFileName, ".iar", m_archiveDirectory, true);

--- a/WhiteCore/Modules/Archivers/Region/ArchiveReadRequest.cs
+++ b/WhiteCore/Modules/Archivers/Region/ArchiveReadRequest.cs
@@ -25,6 +25,15 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Xml;
+using OpenMetaverse;
+using WhiteCore.Framework.ClientInterfaces;
 using WhiteCore.Framework.ConsoleFramework;
 using WhiteCore.Framework.Modules;
 using WhiteCore.Framework.PresenceInfo;
@@ -35,15 +44,6 @@ using WhiteCore.Framework.Serialization.External;
 using WhiteCore.Framework.Services;
 using WhiteCore.Framework.Services.ClassHelpers.Assets;
 using WhiteCore.Framework.Utilities;
-using OpenMetaverse;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.IO.Compression;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Xml;
-using WhiteCore.Framework.ClientInterfaces;
 
 namespace WhiteCore.Modules.Archivers
 {
@@ -108,7 +108,7 @@ namespace WhiteCore.Modules.Archivers
                 if (stream == null)
                 {
                     MainConsole.Instance.Error(
-                        "[ARCHIVER]: We could not find the file specified, or the file was invalid: " + loadPath);
+                        "[Archiver]: We could not find the file specified, or the file was invalid: " + loadPath);
                     return;
                 }
                 m_loadStream = new GZipStream(stream, CompressionMode.Decompress);
@@ -116,7 +116,7 @@ namespace WhiteCore.Modules.Archivers
             catch (EntryPointNotFoundException e)
             {
                 MainConsole.Instance.ErrorFormat(
-                    "[ARCHIVER]: Mismatch between Mono and zlib1g library version when trying to create compression stream."
+                    "[Archiver]: Mismatch between Mono and zlib1g library version when trying to create compression stream."
                     + "If you've manually installed Mono, have you appropriately updated zlib1g as well?");
                 MainConsole.Instance.Error(e);
             }
@@ -185,10 +185,10 @@ namespace WhiteCore.Modules.Archivers
             if (!m_merge)
             {
                 DateTime before = DateTime.Now;
-                MainConsole.Instance.Info("[ARCHIVER]: Clearing all existing scene objects");
+                MainConsole.Instance.Info("[Archiver]: Clearing all existing scene objects");
                 if (backup != null)
                     backup.DeleteAllSceneObjects();
-                MainConsole.Instance.Info("[ARCHIVER]: Cleared all existing scene objects in " +
+                MainConsole.Instance.Info("[Archiver]: Cleared all existing scene objects in " +
                                           (DateTime.Now - before).Minutes + ":" + (DateTime.Now - before).Seconds);
             }
 
@@ -215,7 +215,7 @@ namespace WhiteCore.Modules.Archivers
             Dictionary<UUID, UUID> assetBinaryChangeRecord = new Dictionary<UUID, UUID>();
             Queue<UUID> assets2Save = new Queue<UUID>();
 
-            MainConsole.Instance.Info("[ARCHIVER]: Commencing load from archive");
+            MainConsole.Instance.Info("[Archiver]: Commencing load from archive");
             int ticker = 0;
             try
             {
@@ -241,8 +241,7 @@ namespace WhiteCore.Modules.Archivers
                     {
                         seneObjectGroups.Add(data);
                         if (seneObjectGroups.Count % 100 == 0)
-                            MainConsole.Instance.InfoFormat("[ARCHIVER]: Found {0} scene object groups...",seneObjectGroups.Count);
-
+                            MainConsole.Instance.InfoFormat("[Archiver]: Found {0} scene object groups...",seneObjectGroups.Count);
                     }
                     else if (!m_skipAssets && filePath.StartsWith(ArchiveConstants.ASSETS_PATH))
                     {
@@ -276,7 +275,7 @@ namespace WhiteCore.Modules.Archivers
                             failedAssetRestores++;
 
                         if ((successfulAssetRestores + failedAssetRestores)%100 == 0)
-                            MainConsole.Instance.Info("[ARCHIVER]: Loaded " + successfulAssetRestores +
+                            MainConsole.Instance.Info("[Archiver]: Loaded " + successfulAssetRestores +
                                                       " assets and failed to load " + failedAssetRestores + " assets...");
                     }
                     else if (!m_skipTerrain && filePath.StartsWith(ArchiveConstants.TERRAINS_PATH))
@@ -299,7 +298,7 @@ namespace WhiteCore.Modules.Archivers
                 }
 
                 MainConsole.Instance.CleanInfo("");
-                MainConsole.Instance.Info("[ARCHIVER]: Saving loaded assets");
+                MainConsole.Instance.Info("[Archiver]: Saving loaded assets");
                 ticker = 0;
 
                 // Save Assets
@@ -316,16 +315,16 @@ namespace WhiteCore.Modules.Archivers
                         SaveNonBinaryAssets(assetid, assetNonBinaryCollection[assetid], assetBinaryChangeRecord);
                         savingAssetsCount++;
                         if ((savingAssetsCount)%100 == 0)
-                            MainConsole.Instance.Info("[ARCHIVER]: Saving " + savingAssetsCount + " assets...");
+                            MainConsole.Instance.Info("[Archiver]: Saving " + savingAssetsCount + " assets...");
                     }
                     catch (Exception ex)
                     {
-                        MainConsole.Instance.Info("[ARCHIVER]: Exception in saving an asset: " + ex.ToString());
+                        MainConsole.Instance.Info("[Archiver]: Exception in saving an asset: " + ex.ToString());
                     }
                 }
 
                 MainConsole.Instance.CleanInfo("");
-                MainConsole.Instance.Info("[ARCHIVER]: Saving loaded objects");
+                MainConsole.Instance.Info("[Archiver]: Saving loaded objects");
                 ticker = 0;
                 foreach (byte[] data2 in seneObjectGroups)
                 {
@@ -412,7 +411,6 @@ namespace WhiteCore.Modules.Archivers
 
                                 // ..and possible group ID's
                                 kvp.Value.GroupID = ResolveGroupUuid(kvp.Value.GroupID);
-
                             }
                         }
                     }
@@ -435,7 +433,7 @@ namespace WhiteCore.Modules.Archivers
                     }
                     sceneObjectsLoadedCount++;
                     if (sceneObjectsLoadedCount%100 == 0)
-                        MainConsole.Instance.Info("[ARCHIVER]: Loaded " + sceneObjectsLoadedCount + " objects...");
+                        MainConsole.Instance.Info("[Archiver]: Loaded " + sceneObjectsLoadedCount + " objects...");
                 }
                 assetNonBinaryCollection.Clear();
                 assetBinaryChangeRecord.Clear();
@@ -444,7 +442,7 @@ namespace WhiteCore.Modules.Archivers
             catch (Exception e)
             {
                 MainConsole.Instance.ErrorFormat(
-                    "[ARCHIVER]: Aborting load with error in archive file {0}.  {1}", filePath, e);
+                    "[Archiver]: Aborting load with error in archive file {0}.  {1}", filePath, e);
                 m_errorMessage += e.ToString();
                 m_scene.EventManager.TriggerOarFileLoaded(UUID.Zero.Guid, m_errorMessage);
                 return false;
@@ -480,31 +478,30 @@ namespace WhiteCore.Modules.Archivers
 
             if (!m_skipAssets)
             {
-                MainConsole.Instance.InfoFormat("[ARCHIVER]: Restored {0} assets", successfulAssetRestores);
+                MainConsole.Instance.InfoFormat("[Archiver]: Restored {0} assets", successfulAssetRestores);
 
                 if (failedAssetRestores > 0)
                 {
-                    MainConsole.Instance.ErrorFormat("[ARCHIVER]: Failed to load {0} assets", failedAssetRestores);
+                    MainConsole.Instance.ErrorFormat("[Archiver]: Failed to load {0} assets", failedAssetRestores);
                     m_errorMessage += String.Format("Failed to load {0} assets", failedAssetRestores);
                 }
             }
 
-
             // Reload serialized parcels
             if (!m_skipTerrain)
             {
-                MainConsole.Instance.InfoFormat ("[ARCHIVER]: Loading {0} parcels.  Please wait.", landData.Count);
+                MainConsole.Instance.InfoFormat ("[Archiver]: Loading {0} parcels.  Please wait.", landData.Count);
 
                 IParcelManagementModule parcelManagementModule = m_scene.RequestModuleInterface<IParcelManagementModule> ();
                 if (parcelManagementModule != null)
                     parcelManagementModule.IncomingLandDataFromOAR (landData, m_merge, new Vector2 (m_offsetX, m_offsetY));
 
-                MainConsole.Instance.InfoFormat ("[ARCHIVER]: Restored {0} parcels.", landData.Count);
+                MainConsole.Instance.InfoFormat ("[Archiver]: Restored {0} parcels.", landData.Count);
             }
             //Clean it out
             landData.Clear();
 
-            MainConsole.Instance.InfoFormat("[ARCHIVER]: Successfully loaded archive in " +
+            MainConsole.Instance.InfoFormat("[Archiver]: Successfully loaded archive in " +
                                             (DateTime.Now - start).Minutes + ":" + (DateTime.Now - start).Seconds);
 
             m_validUserUuids.Clear();
@@ -676,7 +673,7 @@ namespace WhiteCore.Modules.Archivers
             if (i == -1)
             {
                 MainConsole.Instance.ErrorFormat(
-                    "[ARCHIVER]: Could not find extension information in asset path {0} since it's missing the separator {1}.  Skipping",
+                    "[Archiver]: Could not find extension information in asset path {0} since it's missing the separator {1}.  Skipping",
                     assetPath, ArchiveConstants.ASSET_EXTENSION_SEPARATOR);
                 asset = null;
                 return false;
@@ -690,13 +687,13 @@ namespace WhiteCore.Modules.Archivers
                 AssetType assetType = ArchiveConstants.EXTENSION_TO_ASSET_TYPE[extension];
 
                 if (assetType == AssetType.Unknown)
-                    MainConsole.Instance.WarnFormat("[ARCHIVER]: Importing {0} byte asset {1} with unknown type",
+                    MainConsole.Instance.WarnFormat("[Archiver]: Importing {0} byte asset {1} with unknown type",
                                                     data.Length, uuid);
                 asset = new AssetBase(UUID.Parse(uuid), String.Empty, assetType, UUID.Zero) {Data = data};
                 return true;
             }
             MainConsole.Instance.ErrorFormat(
-                "[ARCHIVER]: Tried to de-archive data with path {0} with an unknown type extension {1}",
+                "[Archiver]: Tried to de-archive data with path {0} with an unknown type extension {1}",
                 assetPath, extension);
             asset = null;
             return false;
@@ -743,7 +740,7 @@ namespace WhiteCore.Modules.Archivers
             catch (Exception e)
             {
                 MainConsole.Instance.ErrorFormat(
-                    "[ARCHIVER]: Could not parse region settings file {0}.  Ignoring.  Exception was {1}",
+                    "[Archiver]: Could not parse region settings file {0}.  Ignoring.  Exception was {1}",
                     settingsPath, e);
                 return;
             }
@@ -775,9 +772,8 @@ namespace WhiteCore.Modules.Archivers
             terrainModule.LoadFromStream(terrainPath, ms, m_offsetX, m_offsetY);
             ms.Close();
 
-            MainConsole.Instance.DebugFormat("[ARCHIVER]: Restored terrain {0}", terrainPath);
+            MainConsole.Instance.DebugFormat("[Archiver]: Restored terrain {0}", terrainPath);
         }
-
 
         LandData LoadLandData(byte[] data)
         {
@@ -825,7 +821,6 @@ namespace WhiteCore.Modules.Archivers
             parcel.ParcelAccessList = parcelAccess;
 
             return parcel;
-
         }
 
         /// <summary>

--- a/WhiteCore/Modules/Archivers/Region/ArchiveWriteRequestExecution.cs
+++ b/WhiteCore/Modules/Archivers/Region/ArchiveWriteRequestExecution.cs
@@ -85,7 +85,7 @@ namespace WhiteCore.Modules.Archivers
                 m_archiveWriter.Close();
             }
 
-            MainConsole.Instance.InfoFormat("[ARCHIVER]: Finished writing out OAR for {0}",
+            MainConsole.Instance.InfoFormat("[Archiver]: Finished writing out OAR for {0}",
                                             m_scene.RegionInfo.RegionName);
 
             m_scene.EventManager.TriggerOarFileSaved(m_requestId, String.Empty);
@@ -95,18 +95,17 @@ namespace WhiteCore.Modules.Archivers
         {
             foreach (UUID uuid in assetsNotFoundUuids)
             {
-                MainConsole.Instance.DebugFormat("[ARCHIVER]: Could not find asset {0}", uuid);
+                MainConsole.Instance.DebugFormat("[Archiver]: Could not find asset {0}", uuid);
             }
+            
+            //MainConsole.Instance.InfoFormat(
+            //    "[Archiver]: Received {0} of {1} assets requested", assetsFoundUuids.Count, assetsFoundUuids.Count + assetsNotFoundUuids.Count);
 
-//            MainConsole.Instance.InfoFormat(
-//                "[ARCHIVER]: Received {0} of {1} assets requested",
-//                assetsFoundUuids.Count, assetsFoundUuids.Count + assetsNotFoundUuids.Count);
-
-            MainConsole.Instance.InfoFormat("[ARCHIVER]: Creating archive file.  This may take some time.");
+            MainConsole.Instance.InfoFormat("[Archiver]: Creating archive file.  This may take some time.");
 
             // Write out control file
             m_archiveWriter.WriteFile(ArchiveConstants.CONTROL_FILE_PATH, Create0p2ControlFile());
-            MainConsole.Instance.InfoFormat("[ARCHIVER]: Added control file to archive.");
+            MainConsole.Instance.InfoFormat("[Archiver]: Added control file to archive.");
 
             // Write out region settings
             string settingsPath
@@ -114,7 +113,7 @@ namespace WhiteCore.Modules.Archivers
             m_archiveWriter.WriteFile(settingsPath,
                                       RegionSettingsSerializer.Serialize(m_scene.RegionInfo.RegionSettings));
 
-            MainConsole.Instance.InfoFormat("[ARCHIVER]: Added region settings to archive.");
+            MainConsole.Instance.InfoFormat("[Archiver]: Added region settings to archive.");
 
             // Write out land data (aka parcel) settings
             IParcelManagementModule parcelManagement = m_scene.RequestModuleInterface<IParcelManagementModule>();
@@ -128,7 +127,8 @@ namespace WhiteCore.Modules.Archivers
                     m_archiveWriter.WriteFile(landDataPath, LandDataSerializer.Serialize(landData));
                 }
             }
-            MainConsole.Instance.InfoFormat("[ARCHIVER]: Added parcel settings to archive.");
+
+            MainConsole.Instance.InfoFormat("[Archiver]: Added parcel settings to archive.");
 
             // Write out terrain
             string terrainPath
@@ -139,18 +139,18 @@ namespace WhiteCore.Modules.Archivers
             m_archiveWriter.WriteFile(terrainPath, ms.ToArray());
             ms.Close();
 
-            MainConsole.Instance.InfoFormat("[ARCHIVER]: Added terrain information to archive.");
+            MainConsole.Instance.InfoFormat("[Archiver]: Added terrain information to archive.");
 
             // Write out scene object metadata
             foreach (ISceneEntity sceneObject in m_sceneObjects)
             {
-                //MainConsole.Instance.DebugFormat("[ARCHIVER]: Saving {0} {1}, {2}", entity.Name, entity.UUID, entity.GetType());
+                //MainConsole.Instance.DebugFormat("[Archiver]: Saving {0} {1}, {2}", entity.Name, entity.UUID, entity.GetType());
 
                 string serializedObject = m_serialiser.SerializeGroupToXml2(sceneObject);
                 m_archiveWriter.WriteFile(ArchiveHelpers.CreateObjectPath(sceneObject), serializedObject);
             }
 
-            MainConsole.Instance.InfoFormat("[ARCHIVER]: Added scene objects to archive.");
+            MainConsole.Instance.InfoFormat("[Archiver]: Added scene objects to archive.");
         }
 
         /// <summary>

--- a/WhiteCore/Modules/Archivers/Region/ArchiveWriteRequestPreparation.cs
+++ b/WhiteCore/Modules/Archivers/Region/ArchiveWriteRequestPreparation.cs
@@ -25,17 +25,17 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using WhiteCore.Framework.ConsoleFramework;
-using WhiteCore.Framework.Modules;
-using WhiteCore.Framework.SceneInfo;
-using WhiteCore.Framework.SceneInfo.Entities;
-using WhiteCore.Framework.Serialization;
-using OpenMetaverse;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using OpenMetaverse;
+using WhiteCore.Framework.ConsoleFramework;
+using WhiteCore.Framework.Modules;
+using WhiteCore.Framework.SceneInfo;
+using WhiteCore.Framework.SceneInfo.Entities;
+using WhiteCore.Framework.Serialization;
 
 namespace WhiteCore.Modules.Archivers
 {
@@ -70,7 +70,7 @@ namespace WhiteCore.Modules.Archivers
             catch (EntryPointNotFoundException e)
             {
                 MainConsole.Instance.ErrorFormat(
-                    "[ARCHIVER]: Mismatch between Mono and zlib1g library version when trying to create compression stream."
+                    "[Archiver]: Mismatch between Mono and zlib1g library version when trying to create compression stream."
                     + "If you've manually installed Mono, have you appropriately updated zlib1g as well?");
                 MainConsole.Instance.Error(e);
             }
@@ -124,13 +124,13 @@ namespace WhiteCore.Modules.Archivers
             }
 
             MainConsole.Instance.InfoFormat(
-                "[ARCHIVER]: {0} scene objects to serialize requiring save of {1} assets",
+                "[Archiver]: {0} scene objects to serialize requiring save of {1} assets",
                 sceneObjects.Count, assetUuids.Count);
 
             if (numObjectsSkippedPermissions > 0)
             {
                 MainConsole.Instance.DebugFormat(
-                    "[ARCHIVER]: {0} scene objects skipped due to lack of permissions",
+                    "[Archiver]: {0} scene objects skipped due to lack of permissions",
                     numObjectsSkippedPermissions);
             }
 
@@ -219,7 +219,6 @@ namespace WhiteCore.Modules.Archivers
                     canTransfer |= (obj.EveryoneMask & (uint) PermissionMask.Copy) != 0;
                 }
 
-
                 bool partPermitted = true;
                 if (checkPermissions.Contains("C") && !canCopy)
                     partPermitted = false;
@@ -227,7 +226,7 @@ namespace WhiteCore.Modules.Archivers
                     partPermitted = false;
 
                 //string name = (objGroup.PrimCount == 1) ? objGroup.Name : string.Format("{0} ({1}/{2})", obj.Name, primNumber, objGroup.PrimCount);
-                //MainConsole.Instance.DebugFormat("[ARCHIVER]: Object permissions: {0}: Base={1:X4}, Owner={2:X4}, Everyone={3:X4}, permissionClass={4}, checkPermissions={5}, canCopy={6}, canTransfer={7}, permitted={8}",
+                //MainConsole.Instance.DebugFormat("[Archiver]: Object permissions: {0}: Base={1:X4}, Owner={2:X4}, Everyone={3:X4}, permissionClass={4}, checkPermissions={5}, canCopy={6}, canTransfer={7}, permitted={8}",
                 //    name, obj.BaseMask, obj.OwnerMask, obj.EveryoneMask,
                 //    permissionClass, checkPermissions, canCopy, canTransfer, permitted);
 

--- a/WhiteCore/Modules/Archivers/Region/ArchiverModule.cs
+++ b/WhiteCore/Modules/Archivers/Region/ArchiverModule.cs
@@ -33,6 +33,7 @@ using Nini.Config;
 using WhiteCore.Framework.ConsoleFramework;
 using WhiteCore.Framework.Modules;
 using WhiteCore.Framework.SceneInfo;
+using WhiteCore.Framework.Utilities;
 
 namespace WhiteCore.Modules.Archivers
 {

--- a/WhiteCore/Modules/Archivers/Region/ArchiverModule.cs
+++ b/WhiteCore/Modules/Archivers/Region/ArchiverModule.cs
@@ -25,14 +25,14 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using WhiteCore.Framework.ConsoleFramework;
-using WhiteCore.Framework.Modules;
-using WhiteCore.Framework.SceneInfo;
-using Nini.Config;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Nini.Config;
+using WhiteCore.Framework.ConsoleFramework;
+using WhiteCore.Framework.Modules;
+using WhiteCore.Framework.SceneInfo;
 
 namespace WhiteCore.Modules.Archivers
 {
@@ -60,17 +60,16 @@ namespace WhiteCore.Modules.Archivers
             get { return null; }
         }
 
-
         public void Initialise(IConfigSource source)
         {
-            //MainConsole.Instance.Debug("[ARCHIVER] Initializing");
+            //MainConsole.Instance.Debug("[Archiver] Initializing");
         }
 
         public void AddRegion(IScene scene)
         {
             m_scene = scene;
             m_scene.RegisterModuleInterface<IRegionArchiverModule>(this);
-            //MainConsole.Instance.DebugFormat("[ARCHIVER]: Enabled for region {0}", scene.RegionInfo.RegionName);
+            //MainConsole.Instance.DebugFormat("[Archiver]: Enabled for region {0}", scene.RegionInfo.RegionName);
         }
 
         public void RegionLoaded(IScene scene)
@@ -169,7 +168,6 @@ namespace WhiteCore.Modules.Archivers
             return DearchiveRegion(newParams.Count > 2 ? newParams[2] : DEFAULT_OAR_BACKUP_FILENAME, mergeOar, skipAssets,
                             skipTerrain, offsetX, offsetY, offsetZ, flipX, flipY,
                             useParcelOwnership, checkOwnership);
-
         }
 
         /// <summary>
@@ -207,7 +205,7 @@ namespace WhiteCore.Modules.Archivers
         public void ArchiveRegion(string savePath, Guid requestId, string permissions)
         {
             MainConsole.Instance.InfoFormat(
-                "[ARCHIVER]: Writing archive for region {0} to {1}", m_scene.RegionInfo.RegionName, savePath);
+                "[Archiver]: Writing archive for region {0} to {1}", m_scene.RegionInfo.RegionName, savePath);
 
             new ArchiveWriteRequestPreparation(m_scene, savePath, requestId, permissions).ArchiveRegion();
         }
@@ -227,7 +225,7 @@ namespace WhiteCore.Modules.Archivers
                                     bool useParcelOwnership, bool checkOwnership)
         {
             MainConsole.Instance.InfoFormat(
-                "[ARCHIVER]: Loading archive to region {0} from {1}", m_scene.RegionInfo.RegionName, loadPath);
+                "[Archiver]: Loading archive to region {0} from {1}", m_scene.RegionInfo.RegionName, loadPath);
 
             var archiveRead = new ArchiveReadRequest (m_scene, loadPath, merge, skipAssets, skipTerrain, offsetX,
                                   offsetY, offsetZ, flipX, flipY, useParcelOwnership, checkOwnership);

--- a/WhiteCore/Modules/Archivers/Region/ArchiverModule.cs
+++ b/WhiteCore/Modules/Archivers/Region/ArchiverModule.cs
@@ -44,7 +44,7 @@ namespace WhiteCore.Modules.Archivers
         /// <value>
         ///     The file used to load and save an opensimulator archive if no filename has been specified
         /// </value>
-        protected const string DEFAULT_OAR_BACKUP_FILENAME = "region.oar";
+        protected const string DEFAULT_OAR_BACKUP_FILENAME = Constants.DEFAULT_OAR_BACKUP_FILENAME;
 
         private IScene m_scene;
 

--- a/WhiteCore/Modules/Archivers/Region/AssetsArchiver.cs
+++ b/WhiteCore/Modules/Archivers/Region/AssetsArchiver.cs
@@ -64,47 +64,48 @@ namespace WhiteCore.Modules.Archivers
             WriteData(asset);
         }
 
-        //        protected void WriteMetadata(TarArchiveWriter archive)
-//        {
-//            StringWriter sw = new StringWriter();
-//            XmlTextWriter xtw = new XmlTextWriter(sw);
-//
-//            xtw.Formatting = Formatting.Indented;
-//            xtw.WriteStartDocument();
-//
-//            xtw.WriteStartElement("assets");
-//
-//            foreach (UUID uuid in m_assets.Keys)
-//            {
-//                AssetBase asset = m_assets[uuid];
-//
-//                if (asset != null)
-//                {
-//                    xtw.WriteStartElement("asset");
-//
-//                    string extension = string.Empty;
-//
-//                    if (ArchiveConstants.ASSET_TYPE_TO_EXTENSION.ContainsKey(asset.Type))
-//                    {
-//                        extension = ArchiveConstants.ASSET_TYPE_TO_EXTENSION[asset.Type];
-//                    }
-//
-//                    xtw.WriteElementString("filename", uuid.ToString() + extension);
-//
-//                    xtw.WriteElementString("name", asset.Name);
-//                    xtw.WriteElementString("description", asset.Description);
-//                    xtw.WriteElementString("asset-type", asset.Type.ToString());
-//
-//                    xtw.WriteEndElement();
-//                }
-//            }
-//
-//            xtw.WriteEndElement();
-//
-//            xtw.WriteEndDocument();
-//
-//            archive.WriteFile("assets.xml", sw.ToString());
-//        }
+        /*
+        protected void WriteMetadata(TarArchiveWriter archive)
+        {
+            StringWriter sw = new StringWriter();
+            XmlTextWriter xtw = new XmlTextWriter(sw);
+
+            xtw.Formatting = Formatting.Indented;
+            xtw.WriteStartDocument();
+
+            xtw.WriteStartElement("assets");
+
+            foreach (UUID uuid in m_assets.Keys)
+            {
+                AssetBase asset = m_assets[uuid];
+
+                if (asset != null)
+                {
+                    xtw.WriteStartElement("asset");
+
+                    string extension = string.Empty;
+
+                    if (ArchiveConstants.ASSET_TYPE_TO_EXTENSION.ContainsKey(asset.Type))
+                    {
+                        extension = ArchiveConstants.ASSET_TYPE_TO_EXTENSION[asset.Type];
+                    }
+
+                    xtw.WriteElementString("filename", uuid.ToString() + extension);
+
+                    xtw.WriteElementString("name", asset.Name);
+                    xtw.WriteElementString("description", asset.Description);
+                    xtw.WriteElementString("asset-type", asset.Type.ToString());
+
+                    xtw.WriteEndElement();
+                }
+            }
+
+            xtw.WriteEndElement();
+
+            xtw.WriteEndDocument();
+
+            archive.WriteFile("assets.xml", sw.ToString());
+        } */
 
         /// <summary>
         ///     Write asset data files to the given archive
@@ -124,7 +125,7 @@ namespace WhiteCore.Modules.Archivers
             else
             {
                 MainConsole.Instance.ErrorFormat(
-                    "[ARCHIVER]: Unrecognized asset type {0} with uuid {1}.  This asset will be saved but not reloaded",
+                    "[Archiver]: Unrecognized asset type {0} with uuid {1}.  This asset will be saved but not reloaded",
                     asset.Type, asset.ID);
             }
 
@@ -134,10 +135,10 @@ namespace WhiteCore.Modules.Archivers
 
             m_assetsWritten++;
 
-            //MainConsole.Instance.DebugFormat("[ARCHIVER]: Added asset {0}", m_assetsWritten);
+            //MainConsole.Instance.DebugFormat("[Archiver]: Added asset {0}", m_assetsWritten);
 
             if (m_assetsWritten%LOG_ASSET_LOAD_NOTIFICATION_INTERVAL == 0)
-                MainConsole.Instance.InfoFormat("[ARCHIVER]: Added {0} assets to archive", m_assetsWritten);
+                MainConsole.Instance.InfoFormat("[Archiver]: Added {0} assets to archive", m_assetsWritten);
         }
 
         /// <summary>

--- a/WhiteCore/Modules/Archivers/Region/AssetsDearchiver.cs
+++ b/WhiteCore/Modules/Archivers/Region/AssetsDearchiver.cs
@@ -25,17 +25,16 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
-using WhiteCore.Framework.ConsoleFramework;
-using WhiteCore.Framework.Serialization;
-using WhiteCore.Framework.Services;
-using WhiteCore.Framework.Services.ClassHelpers.Assets;
-using OpenMetaverse;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Xml;
+using OpenMetaverse;
+using WhiteCore.Framework.ConsoleFramework;
+using WhiteCore.Framework.Serialization;
+using WhiteCore.Framework.Services;
+using WhiteCore.Framework.Services.ClassHelpers.Assets;
 
 namespace WhiteCore.Modules.Archivers
 {
@@ -154,7 +153,7 @@ namespace WhiteCore.Modules.Archivers
                     filename = filename.Remove(filename.Length - extension.Length);
                 }
 
-                MainConsole.Instance.DebugFormat("[ARCHIVER]: Importing asset {0}", filename);
+                MainConsole.Instance.DebugFormat("[Archiver]: Importing asset {0}", filename);
 
                 AssetBase asset = new AssetBase(filename, metadata.Name, (AssetType) metadata.AssetType, UUID.Zero)
                                       {Description = metadata.Description, Data = data, MetaOnly = false};
@@ -163,7 +162,7 @@ namespace WhiteCore.Modules.Archivers
             else
             {
                 MainConsole.Instance.ErrorFormat(
-                    "[DEARCHIVER]: Tried to de-archive data with filename {0} without any corresponding metadata",
+                    "[De-Archiver]: Tried to de-archive data with filename {0} without any corresponding metadata",
                     assetPath);
             }
         }

--- a/WhiteCore/Modules/Archivers/Region/AssetsRequest.cs
+++ b/WhiteCore/Modules/Archivers/Region/AssetsRequest.cs
@@ -25,7 +25,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -111,7 +110,7 @@ namespace WhiteCore.Modules.Archivers
         {
             m_requestState = RequestState.Running;
 
-            MainConsole.Instance.DebugFormat("[ARCHIVER]: AssetsRequest executed looking for {0} assets",
+            MainConsole.Instance.DebugFormat("[Archiver]: AssetsRequest executed looking for {0} assets",
                                              m_repliesRequired);
 
             // We can stop here if there are no assets to fetch
@@ -159,12 +158,12 @@ namespace WhiteCore.Modules.Archivers
                 }
 
                 MainConsole.Instance.ErrorFormat(
-                    "[ARCHIVER]: Asset service failed to return information about {0} requested assets", uuids.Count);
+                    "[Archiver]: Asset service failed to return information about {0} requested assets", uuids.Count);
 
                 int i = 0;
                 foreach (UUID uuid in uuids)
                 {
-                    MainConsole.Instance.ErrorFormat("[ARCHIVER]: No information about asset {0} received", uuid);
+                    MainConsole.Instance.ErrorFormat("[Archiver]: No information about asset {0} received", uuid);
 
                     if (++i >= MAX_UUID_DISPLAY_ON_TIMEOUT)
                         break;
@@ -172,13 +171,13 @@ namespace WhiteCore.Modules.Archivers
 
                 if (uuids.Count > MAX_UUID_DISPLAY_ON_TIMEOUT)
                     MainConsole.Instance.ErrorFormat(
-                        "[ARCHIVER]: (... {0} more not shown)", uuids.Count - MAX_UUID_DISPLAY_ON_TIMEOUT);
+                        "[Archiver]: (... {0} more not shown)", uuids.Count - MAX_UUID_DISPLAY_ON_TIMEOUT);
 
-                MainConsole.Instance.Error("[ARCHIVER]: OAR save aborted.");
+                MainConsole.Instance.Error("[Archiver]: OAR save aborted.");
             }
             catch (Exception e)
             {
-                MainConsole.Instance.ErrorFormat("[ARCHIVER]: Timeout handler exception {0}", e);
+                MainConsole.Instance.ErrorFormat("[Archiver]: Timeout handler exception {0}", e);
             }
             finally
             {
@@ -192,7 +191,7 @@ namespace WhiteCore.Modules.Archivers
             if (fetchedAsset != null && fetchedAsset.Type == (sbyte) AssetType.Unknown)
             {
                 AssetType type = (AssetType) assetType;
-                MainConsole.Instance.InfoFormat("[ARCHIVER]: Rewriting broken asset type for {0} to {1}",
+                MainConsole.Instance.InfoFormat("[Archiver]: Rewriting broken asset type for {0} to {1}",
                                                 fetchedAsset.ID, type);
                 fetchedAsset.Type = (sbyte) type;
             }
@@ -212,14 +211,14 @@ namespace WhiteCore.Modules.Archivers
             {
                 lock (this)
                 {
-                    //MainConsole.Instance.DebugFormat("[ARCHIVER]: Received callback for asset {0}", id);
+                    //MainConsole.Instance.DebugFormat("[Archiver]: Received callback for asset {0}", id);
 
                     m_requestCallbackTimer.Stop();
 
                     if (m_requestState == RequestState.Aborted)
                     {
                         MainConsole.Instance.WarnFormat(
-                            "[ARCHIVER]: Received information about asset {0} after archive save abortion.  Ignoring.",
+                            "[Archiver]: Received information about asset {0} after archive save abortion.  Ignoring.",
                             assetID);
 
                         return;
@@ -227,13 +226,13 @@ namespace WhiteCore.Modules.Archivers
 
                     if (asset != null)
                     {
-//                        MainConsole.Instance.DebugFormat("[ARCHIVER]: Writing asset {0}", id);
+                        //MainConsole.Instance.DebugFormat("[Archiver]: Writing asset {0}", id);
                         m_foundAssetUuids.Add(asset.ID);
                         m_assetsArchiver.WriteAsset(asset);
                     }
                     else
                     {
-//                        MainConsole.Instance.DebugFormat("[ARCHIVER]: Recording asset {0} as not found", id);
+                        //MainConsole.Instance.DebugFormat("[Archiver]: Recording asset {0} as not found", id);
                         m_notFoundAssetUuids.Add(new UUID(assetID));
                     }
 
@@ -242,7 +241,7 @@ namespace WhiteCore.Modules.Archivers
                         m_requestState = RequestState.Completed;
 
                         MainConsole.Instance.InfoFormat(
-                            "[ARCHIVER]: Successfully added {0} assets ({1} assets notified missing)",
+                            "[Archiver]: Successfully added {0} assets ({1} assets notified missing)",
                             m_foundAssetUuids.Count, m_notFoundAssetUuids.Count);
 
                         // We want to stop using the asset cache thread asap 
@@ -255,7 +254,7 @@ namespace WhiteCore.Modules.Archivers
             }
             catch (Exception e)
             {
-                MainConsole.Instance.ErrorFormat("[ARCHIVER]: AssetRequestCallback failed with {0}", e);
+                MainConsole.Instance.ErrorFormat("[Archiver]: AssetRequestCallback failed with {0}", e);
             }
         }
 
@@ -271,7 +270,7 @@ namespace WhiteCore.Modules.Archivers
             catch (Exception e)
             {
                 MainConsole.Instance.ErrorFormat(
-                    "[ARCHIVER]: Terminating archive creation since asset requster callback failed with {0}", e);
+                    "[Archiver]: Terminating archive creation since asset requster callback failed with {0}", e);
             }
         }
 

--- a/WhiteCore/Modules/World/DefaultInventoryIARLoader/DefaultInventoryIARLoader.cs
+++ b/WhiteCore/Modules/World/DefaultInventoryIARLoader/DefaultInventoryIARLoader.cs
@@ -135,12 +135,12 @@ namespace WhiteCore.Modules.DefaultInventoryIARLoader
 
             if (alreadyExists)
             {
-                MainConsole.Instance.InfoFormat("[LIBRARY INVENTORY]: Found previously loaded IAR file {0}, ignoring.",
+                MainConsole.Instance.InfoFormat("[Library Inventory]: Found previously loaded IAR file {0}, ignoring.",
                                                 iarFileName);
                 return;
             }
 
-            MainConsole.Instance.InfoFormat("[LIBRARY INVENTORY]: Loading IAR file {0}", iarFileName);
+            MainConsole.Instance.InfoFormat("[Library Inventory]: Loading IAR file {0}", iarFileName);
             InventoryFolderBase rootFolder = m_MockScene.InventoryService.GetRootFolder(uinfo.PrincipalID);
 
             if (rootFolder == null)

--- a/WhiteCore/Modules/World/Startup/Backup.cs
+++ b/WhiteCore/Modules/World/Startup/Backup.cs
@@ -25,7 +25,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -314,12 +313,12 @@ namespace WhiteCore.Modules.Startup
                     {
                         if (group == null)
                         {
-                            MainConsole.Instance.Warn("[BackupModule]: Null object while loading objects, ignoring.");
+                            MainConsole.Instance.Warn("[Backup Module]: Null object while loading objects, ignoring.");
                             continue;
                         }
                         if (group.RootChild.Shape == null)
                         {
-                            MainConsole.Instance.Warn("[BackupModule]: Broken object (" + group.Name +
+                            MainConsole.Instance.Warn("[Backup Module]: Broken object (" + group.Name +
                                                       ") found while loading objects, removing it from the database.");
                             //WTF went wrong here? Remove by passing it by on loading
                             continue;
@@ -329,7 +328,7 @@ namespace WhiteCore.Modules.Startup
                                                     group.RootChild.Shape.PCode == (byte) PCode.Prim ||
                                                     group.RootChild.Shape.PCode == (byte) PCode.Avatar)))
                         {
-                            MainConsole.Instance.Warn("[BackupModule]: Broken state for object " + group.Name +
+                            MainConsole.Instance.Warn("[Backup Module]: Broken state for object " + group.Name +
                                                       " while loading objects, removing it from the database.");
                             //WTF went wrong here? Remove by passing it by on loading
                             continue;
@@ -339,7 +338,7 @@ namespace WhiteCore.Modules.Startup
                             group.AbsolutePosition.Y > m_scene.RegionInfo.RegionSizeY + 10 ||
                             group.AbsolutePosition.Y < -10)
                         {
-                            MainConsole.Instance.WarnFormat("[BackupModule]: Object outside the region "+
+                            MainConsole.Instance.WarnFormat("[Backup Module]: Object outside the region "+
                                 "(" + group.Name + ", " + group.AbsolutePosition + ")" +
                                 " found while loading objects, removing it from the database.");
                             //WTF went wrong here? Remove by passing it by on loading
@@ -352,7 +351,7 @@ namespace WhiteCore.Modules.Startup
                         if (group.RootChild == null)
                         {
                             MainConsole.Instance.ErrorFormat(
-                                "[BackupModule] Found a SceneObjectGroup with m_rootPart == null and {0} children",
+                                "[Backup Module] Found a SceneObjectGroup with m_rootPart == null and {0} children",
                                 group.ChildrenEntities().Count);
                             continue;
                         }
@@ -361,11 +360,11 @@ namespace WhiteCore.Modules.Startup
                     catch (Exception ex)
                     {
                         MainConsole.Instance.WarnFormat(
-                            "[BackupModule]: Exception attempting to load object from the database, {0}, continuing...", ex);
+                            "[Backup Module]: Exception attempting to load object from the database, {0}, continuing...", ex);
                     }
                 }
                 LoadingPrims = false;
-                MainConsole.Instance.Info("[BackupModule]: Loaded " + PrimsFromDB.Count + " object(s) in " +
+                MainConsole.Instance.Info("[Backup Module]: Loaded " + PrimsFromDB.Count + " object(s) in " +
                                           m_scene.RegionInfo.RegionName);
                 PrimsFromDB.Clear();
             }
@@ -375,7 +374,7 @@ namespace WhiteCore.Modules.Startup
             /// </summary>
             public void LoadAllLandObjectsFromStorage()
             {
-                MainConsole.Instance.Debug("[BackupModule]: Loading Land Objects from database... ");
+                MainConsole.Instance.Debug("[Backup Module]: Loading Land Objects from database... ");
                 m_scene.EventManager.TriggerIncomingLandDataFromStorage(
                     m_scene.SimulationDataService.LoadLandObjects(), Vector2.Zero);
             }
@@ -397,7 +396,7 @@ namespace WhiteCore.Modules.Startup
             /// </summary>
             public void CreateScriptInstances()
             {
-                MainConsole.Instance.Info("[BackupModule]: Starting scripts in " + m_scene.RegionInfo.RegionName);
+                MainConsole.Instance.Info("[Backup Module]: Starting scripts in " + m_scene.RegionInfo.RegionName);
                 //Set loading prims here to block backup
                 LoadingPrims = true;
                 ISceneEntity[] entities = m_scene.Entities.GetEntities();
@@ -575,7 +574,7 @@ namespace WhiteCore.Modules.Startup
                     return true;
                 }
 
-                //MainConsole.Instance.DebugFormat("[SCENE]: Exit DeleteSceneObject() for {0} {1}", group.Name, group.UUID);
+                //MainConsole.Instance.DebugFormat("[Scene]: Exit DeleteSceneObject() for {0} {1}", group.Name, group.UUID);
                 return false;
             }
 
@@ -777,9 +776,9 @@ namespace WhiteCore.Modules.Startup
                     if (!m_merge)
                     {
                         DateTime before = DateTime.Now;
-                        MainConsole.Instance.Info("[ARCHIVER]: Clearing all existing scene objects");
+                        MainConsole.Instance.Info("[Archiver]: Clearing all existing scene objects");
                         backup.DeleteAllSceneObjects();
-                        MainConsole.Instance.Info("[ARCHIVER]: Cleared all existing scene objects in " +
+                        MainConsole.Instance.Info("[Archiver]: Cleared all existing scene objects in " +
                                                   (DateTime.Now - before).Minutes + ":" +
                                                   (DateTime.Now - before).Seconds);
                         if (parcelModule != null)

--- a/WhiteCore/Server/ServerBase.cs
+++ b/WhiteCore/Server/ServerBase.cs
@@ -46,7 +46,7 @@ namespace WhiteCore.Server
             if (MainConsole.Instance != null)
 			{
 				MainConsole.Instance.DefaultPrompt = "WhiteCore.Server ";
-				MainConsole.Instance.Info ("[WhiteCoreSTARTUP]: Startup completed in " +
+				MainConsole.Instance.Info ("[WhiteCore-Sim Startup]: Startup completed in " +
 					(DateTime.Now - this.StartupTime).TotalSeconds);
 			}
         }

--- a/WhiteCore/Servers/WebServer/ServerBase.cs
+++ b/WhiteCore/Servers/WebServer/ServerBase.cs
@@ -46,7 +46,7 @@ namespace WhiteCore.Server
             if (MainConsole.Instance != null)
             {
                 MainConsole.Instance.DefaultPrompt = "WhiteCore.WebServer ";
-                MainConsole.Instance.Info("[WhiteCoreSTARTUP]: Startup completed in " +
+                MainConsole.Instance.Info("[WhiteCore-Sim Startup]: Startup completed in " +
                                           (DateTime.Now - this.StartupTime).TotalSeconds);
             }
         }

--- a/WhiteCore/Simulation/Base/BaseApplication.cs
+++ b/WhiteCore/Simulation/Base/BaseApplication.cs
@@ -84,12 +84,12 @@ namespace WhiteCore.Simulation.Base
             // Increase the number of IOCP threads available. Mono defaults to a tragically low number
             int workerThreads, iocpThreads;
             ThreadPool.GetMaxThreads(out workerThreads, out iocpThreads);
-            //MainConsole.Instance.InfoFormat("[WHiteCore MAIN]: Runtime gave us {0} worker threads and {1} IOCP threads", workerThreads, iocpThreads);
+            //MainConsole.Instance.InfoFormat("[WhiteCore Main]: Runtime gave us {0} worker threads and {1} IOCP threads", workerThreads, iocpThreads);
             if (workerThreads < 500 || iocpThreads < 1000)
             {
                 workerThreads = 500;
                 iocpThreads = 1000;
-                //MainConsole.Instance.Info("[WHiteCore MAIN]: Bumping up to 500 worker threads and 1000 IOCP threads");
+                //MainConsole.Instance.Info("[WhiteCore Main]: Bumping up to 500 worker threads and 1000 IOCP threads");
                 ThreadPool.SetMaxThreads(workerThreads, iocpThreads);
             }
 
@@ -152,26 +152,26 @@ namespace WhiteCore.Simulation.Base
                 if (!requested)
                 {
                     Console.ForegroundColor = ConsoleColor.Red;
-                    Console.WriteLine ("\n\n************* WhiteCore initial run. *************");
+                    Console.WriteLine ("\n\n************* WhiteCore-Sim initial run. *************");
                     Console.ForegroundColor = ConsoleColor.Yellow;
                     Console.WriteLine (
-                        "\n\n   This appears to be your first time running WhiteCore.\n" +
+                        "\n\n   This appears to be your first time running WhiteCore-Sim.\n" +
                         "If you have already configured your *.ini files, please ignore this warning and press enter;\n" +
-                        "Otherwise type 'yes' and WhiteCore will guide you through the configuration process.\n\n" +
+                        "Otherwise type 'yes' and WhiteCore-Sim will guide you through the configuration process.\n\n" +
                         "Remember, these file names are Case Sensitive in Linux and Proper Cased.\n" +
                         "1. " + WhiteCore_ConfigDir + "/WhiteCore.ini\nand\n" +
                         "2. " + WhiteCore_ConfigDir + "/Sim/Standalone/StandaloneCommon.ini \nor\n" +
                         "3. " + WhiteCore_ConfigDir + "/Grid/GridCommon.ini\n" +
                         "\nAlso, you will want to examine these files in great detail because only the basic system will " +
-                        "load by default. WhiteCore can do a LOT more if you spend a little time going through these files.\n\n");
+                        "load by default. WhiteCore-Sim can do a LOT more if you spend a little time going through these files.\n\n");
                 } else
                 {
                     Console.ForegroundColor = ConsoleColor.Red;
-                    Console.WriteLine ("\n\n************* WhiteCore Configuration *************");
+                    Console.WriteLine ("\n\n************* WhiteCore-Sim Configuration *************");
                     Console.ForegroundColor = ConsoleColor.Yellow;
                     Console.WriteLine (
                         "\n     WhiteCore interactive configuration.\n" +
-                        "Enter 'yes' and WhiteCore will guide you through the configuration process.");
+                        "Enter 'yes' and WhiteCore-Sim will guide you through the configuration process.");
                 }
 
                 // Make sure...
@@ -179,9 +179,11 @@ namespace WhiteCore.Simulation.Base
                 Console.WriteLine ("");
                 Console.WriteLine (" ##  WARNING  ##");
                 Console.WriteLine("This will overwrite any existing configuration files!");
+                Console.WriteLine("It is strongly recommended that you save a backup copy");
+                Console.WriteLine("of your configuration files before proceeding!");
                 Console.ResetColor();
                 Console.WriteLine ("");
-                resp = ReadLine("Do you want to configure WhiteCore now?  (yes/no)", resp);
+                resp = ReadLine("Do you want to configure WhiteCore-Sim now?  (yes/no)", resp);
 
                 if (resp == "yes")
                 {
@@ -204,7 +206,7 @@ namespace WhiteCore.Simulation.Base
 
                     Console.ForegroundColor = ConsoleColor.Green;
                     Console.WriteLine("====================================================================");
-					Console.WriteLine("======================= WhiteCore CONFIGURATOR =====================");
+					Console.WriteLine("======================= WhiteCore-Sim Configurator =================");
                     Console.WriteLine("====================================================================");
                     Console.ResetColor();
 
@@ -333,6 +335,7 @@ namespace WhiteCore.Simulation.Base
                                         newConfig.Set(key, config.Get(key));
                                 }
                             }
+
                             mysql_ini.Save();
                             Console.ForegroundColor = ConsoleColor.Green;
                             Console.WriteLine("Your MySQL.ini has been successfully configured");
@@ -375,7 +378,6 @@ namespace WhiteCore.Simulation.Base
                                 newConfig.Set ("HostName", regionIPAddress);
                             }
                         }
-
 
 						whitecore_ini.Save();
                         Console.ForegroundColor = ConsoleColor.Green;
@@ -455,7 +457,6 @@ namespace WhiteCore.Simulation.Base
                             Console.WriteLine("Your Grid.ini has been successfully configured");
                             Console.ResetColor();
                             Console.WriteLine ("");
-
                         }
                     }
 
@@ -527,6 +528,7 @@ namespace WhiteCore.Simulation.Base
                                     newConfig.Set(key, config.Get(key));
                             }
                         }
+
                         login_ini.Save();
                         Console.ForegroundColor = ConsoleColor.Green;
                         Console.WriteLine("Your Login.ini has been successfully configured");
@@ -574,10 +576,9 @@ namespace WhiteCore.Simulation.Base
                     Console.WriteLine(
                         "To re-run this configurator, enter \"run configurator\" into the console.");
                     Console.ForegroundColor = ConsoleColor.Yellow;
-                    Console.WriteLine(" >> Please restart to use your new configuration. <<");
+                    Console.WriteLine(" >> Please restart WhiteCore-Sim to use your new configuration. <<");
                     Console.ResetColor ();
-                    Console.WriteLine ("");
-                    
+                    Console.WriteLine ("");           
                 }
             }
         }
@@ -679,9 +680,11 @@ namespace WhiteCore.Simulation.Base
         /// <param name="ex"></param>
         public static void HandleCrashException(string msg, Exception ex)
         {
-
             //if (m_saveCrashDumps && Environment.OSVersion.Platform == PlatformID.Win32NT)
             // 20160323 -greythane - not sure why this will not work on *nix as well?
+            // 20160408 -EmperorStarfinder - This appears to not work on either Windows or Nix.
+            // Maybe consider removing the saveCrashDumps as it appears it is writing it to the
+            // logs for WhiteCore.Server and WhiteCore consoles already?
             if (m_saveCrashDumps)
                            {
                 // Log exception to disk
@@ -801,6 +804,7 @@ namespace WhiteCore.Simulation.Base
             {
                 exp.ExceptionPointers = Marshal.GetExceptionPointers();
             }
+
             bool bRet;
             if (exp.ExceptionPointers == IntPtr.Zero)
             {

--- a/WhiteCore/Simulation/Base/MinimalSimulationBase.cs
+++ b/WhiteCore/Simulation/Base/MinimalSimulationBase.cs
@@ -25,7 +25,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -232,10 +231,8 @@ namespace WhiteCore.Simulation.Base
                 if (stpMaxThreads < 2)
                     stpMaxThreads = 2;
                 if (stpMinThreads > stpMaxThreads)
-                    stpMinThreads = stpMaxThreads;
-                
+                    stpMinThreads = stpMaxThreads;           
             }
-
 
             if (Util.FireAndForgetMethod == FireAndForgetMethod.SmartThreadPool)
                 Util.InitThreadPool(stpMinThreads, stpMaxThreads);
@@ -248,10 +245,10 @@ namespace WhiteCore.Simulation.Base
             if (MainConsole.Instance != null)
             {
                 MainConsole.Instance.DefaultPrompt = m_consolePrompt;
-                MainConsole.Instance.Info(string.Format("[MINWhiteCore]: STARTING MIN WhiteCore ({0})...",
+                MainConsole.Instance.Info(string.Format("[Mini WhiteCore-Sim]: Starting Mini WhiteCore-Sim ({0})...",
                                                         (IntPtr.Size == 4 ? "x86" : "x64")));
-                MainConsole.Instance.Info("[MINWhiteCore]: Version : " + Version + "\n");
-                MainConsole.Instance.Info("[MINWhiteCore]: Git Base: " + VersionInfo.GitVersion + "\n");
+                MainConsole.Instance.Info("[Mini WhiteCore-Sim]: Version : " + Version + "\n");
+                MainConsole.Instance.Info("[Mini WhiteCore-Sim]: Git Base: " + VersionInfo.GitVersion + "\n");
             }
         }
 
@@ -260,7 +257,7 @@ namespace WhiteCore.Simulation.Base
         /// </summary>
         public virtual void Startup()
         {
-            MainConsole.Instance.Info("[MINWhiteCore]: Startup completed in " +
+            MainConsole.Instance.Info("[Mini WhiteCore-Sim]: Startup completed in " +
                                       (DateTime.Now - this.StartupTime).TotalSeconds);
         }
 
@@ -521,7 +518,7 @@ namespace WhiteCore.Simulation.Base
         public virtual void HandleForceGC(IScene scene, string[] cmd)
         {
             GC.Collect();
-            MainConsole.Instance.Warn("Garbage collection finished");
+            MainConsole.Instance.Warn("[Garbage Collection Service]: Garbage collection finished");
         }
 
         public virtual void runConfig(IScene scene, string[] cmd)
@@ -564,7 +561,7 @@ namespace WhiteCore.Simulation.Base
                 {
                     server.HostName = hostName;
                 }
-                MainConsole.Instance.Info ("Finished reloading configuration.");
+                MainConsole.Instance.Info ("[WhiteCore-Sim Configuration]: Finished reloading configuration.");
             }
         }
 
@@ -635,10 +632,10 @@ namespace WhiteCore.Simulation.Base
                 }
 
                 if (close)
-                    MainConsole.Instance.Info("[Shutdown]: Terminating");
+                    MainConsole.Instance.Info("[Shut Down]: Terminating");
 
-                MainConsole.Instance.Info("[Shutdown]: Shutdown processing on main thread complete. " +
-                                          (close ? " Exiting..." : ""));
+                MainConsole.Instance.Info("[Shut Down]: Shut down processing on main thread complete. " +
+                                          (close ? " Exiting WhiteCore-Sim..." : ""));
 
                 if (close)
                     Environment.Exit(0);

--- a/WhiteCore/Simulation/Base/SimulationBase.cs
+++ b/WhiteCore/Simulation/Base/SimulationBase.cs
@@ -236,21 +236,21 @@ namespace WhiteCore.Simulation.Base
         {
             MainConsole.Instance.Info("====================================================================");
             MainConsole.Instance.Info(
-				        string.Format("==================== STARTING WhiteCore ({0}) ======================",
+				        string.Format("==================== Starting WhiteCore-Sim ({0}) ======================",
                               (IntPtr.Size == 4 ? "x86" : "x64")));
             MainConsole.Instance.Info("====================================================================");
-            MainConsole.Instance.Info("[WhiteCoreStartup]: Version : " + Version + "\n");
-            MainConsole.Instance.Info("[WhiteCoreStartup]: Git Base: " + VersionInfo.GitVersion + "\n");
+            MainConsole.Instance.Info("[WhiteCore-Sim Startup]: Version : " + Version + "\n");
+            MainConsole.Instance.Info("[WhiteCore-Sim Startup]: Git Base: " + VersionInfo.GitVersion + "\n");
             if (Environment.Is64BitOperatingSystem)
-                MainConsole.Instance.Info("[WhiteCoreStartup]: Running on 64 bit architecture");
+                MainConsole.Instance.Info("[WhiteCore-Sim Startup]: Running on 64 bit architecture");
             // get memory allocation
             Process proc = Process.GetCurrentProcess();
-            MainConsole.Instance.Info("[WhiteCoreStartup]: Allocated RAM " + proc.WorkingSet64);
+            MainConsole.Instance.Info("[WhiteCore-Sim Startup]: Allocated RAM " + proc.WorkingSet64);
             if (Utilities.IsLinuxOs)
             {
                 var pc = new PerformanceCounter ("Mono Memory", "Total Physical Memory");
                 var bytes = pc.RawValue;
-                MainConsole.Instance.InfoFormat ("[WhiteCoreStartup]: Physical RAM (Mbytes): {0}", bytes / 1024000);
+                MainConsole.Instance.InfoFormat ("[WhiteCore-Sim Startup]: Physical RAM (Mbytes): {0}", bytes / 1024000);
             }
 
             SetUpHTTPServer();
@@ -538,7 +538,7 @@ namespace WhiteCore.Simulation.Base
         public virtual void HandleForceGC(IScene scene, string[] cmd)
         {
             GC.Collect();
-            MainConsole.Instance.Warn("Garbage collection finished");
+            MainConsole.Instance.Warn("[Garbage Collection Service]: Garbage collection finished");
         }
 
         public virtual void RunConfig(IScene scene, string[] cmd)
@@ -580,7 +580,7 @@ namespace WhiteCore.Simulation.Base
                 {
                     server.HostName = hostName;
                 }
-                MainConsole.Instance.Info ("Finished reloading configuration.");
+                MainConsole.Instance.Info ("[WhiteCore-Sim Configuration]: Finished reloading configuration.");
             }
         }
 
@@ -651,10 +651,10 @@ namespace WhiteCore.Simulation.Base
                 }
 
                 if (close)
-                    MainConsole.Instance.Info("[SHUTDOWN]: Terminating");
+                    MainConsole.Instance.Info("[Shut Down]: Terminating");
 
-                MainConsole.Instance.Info("[SHUTDOWN]: Shutdown processing on main thread complete. " +
-                                          (close ? " Exiting..." : ""));
+                MainConsole.Instance.Info("[Shut Down]: Shut down processing on main thread complete. " +
+                                          (close ? " Exiting WhiteCore-Sim..." : ""));
                 MainConsole.Instance.CleanInfo("");
                 MainConsole.Instance.CleanInfo("");
 


### PR DESCRIPTION
This is just some minor cleanup that doesn't affect the functionality of WhiteCore.

- Makes the startup on the consoles look better now it will say Starting WhiteCore-Sim and [WhiteCore-Sim Startup]
- Moves the DEFAULT_OAR_BACKUP_FILENAME configuration to constants per conversations with Greythane last year.
- Cleans up a few unnecessary whitespaces
- Organizes some using references

I have fully tested this everything does work correctly for Nix and Windows.
