### PR TITLE
Licensing and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,3 @@ Support is available from various sources.
 
 * Google + community for WhiteCore with a friendly bunch that is happy to answer questions. Find it at https://plus.google.com/communities/113034607546142208907?cfem=1
 
-*NOTE: 
- As of Version 0.9.2, the WhiteCore repository format has changed.  
- The WhiteCore-Optional-Modules repository has also been updated for the new structure.
- To ensure correct compiling, use the latest commits of the WhiteCore-Dev or a release version >= 0.9.2*
-
-*Please see the "Migration to 0.9.2.txt" file for details on files and configurations that will need to be modified*

--- a/README.md
+++ b/README.md
@@ -64,3 +64,10 @@ Support is available from various sources.
 
 * Google + community for WhiteCore with a friendly bunch that is happy to answer questions. Find it at https://plus.google.com/communities/113034607546142208907?cfem=1
 
+*NOTE: 
+ As of Version 0.9.2, the WhiteCore repository format has changed.  
+ The WhiteCore-Optional-Modules repository has also been updated for the new structure.
+ To ensure correct compiling, use the latest commits of the WhiteCore-Dev or a release version >= 0.9.2*
+
+*Please see the "Updating from a pre 0.9.2 version.txt" file for details on files and configurations that will need to be modified
+ The document can be found in the WhiteCoreDocs directory*

--- a/WhiteCore/Physics/BasicPhysicsPlugin/BasicPhysicsActor.cs
+++ b/WhiteCore/Physics/BasicPhysicsPlugin/BasicPhysicsActor.cs
@@ -25,8 +25,8 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-using WhiteCore.Framework.Physics;
 using OpenMetaverse;
+using WhiteCore.Framework.Physics;
 
 namespace WhiteCore.Physics.BasicPhysicsPlugin
 {

--- a/WhiteCore/Physics/BulletSPlugin/BSAPIUnman.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSAPIUnman.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSActorAvatarMove.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSActorAvatarMove.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://virtualnexus.eu/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://virtualnexus.eu/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSActorHover.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSActorHover.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSActorLockAxis.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSActorLockAxis.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSActorMoveToTarget.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSActorMoveToTarget.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://virtualnexus.eu/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://virtualnexus.eu/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSActorSetForce.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSActorSetForce.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSActorSetTorque.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSActorSetTorque.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSActors.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSActors.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSApiTemplate.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSApiTemplate.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSCharacter.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSCharacter.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSConstraint.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSConstraint.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSConstraint6Dof.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSConstraint6Dof.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSConstraintCollection.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSConstraintCollection.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSConstraintHinge.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSConstraintHinge.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSDynamics.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSDynamics.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -23,7 +23,9 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
+ */
+
+ /*
  * The quotations from http://wiki.secondlife.com/wiki/Linden_Vehicle_Tutorial
  * are Copyright (c) 2009 Linden Research, Inc and are used under their license
  * of Creative Commons Attribution-Share Alike 3.0

--- a/WhiteCore/Physics/BulletSPlugin/BSLinkset.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSLinkset.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSLinksetCompound.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSLinksetCompound.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSLinksetConstraints.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSLinksetConstraints.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSMaterials.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSMaterials.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSMotors.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSMotors.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSParam.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSParam.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSPhysObject.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSPhysObject.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSPlugin.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSPlugin.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSPrim.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSPrim.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://virtualnexus.eu/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://virtualnexus.eu/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSPrimDisplaced.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSPrimDisplaced.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -23,8 +23,9 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- * The quotations from http://wiki.secondlife.com/wiki/Linden_Vehicle_Tutorial
+ */
+
+/* The quotations from http://wiki.secondlife.com/wiki/Linden_Vehicle_Tutorial
  * are Copyright (c) 2009 Linden Research, Inc and are used under their license
  * of Creative Commons Attribution-Share Alike 3.0
  * (http://creativecommons.org/licenses/by-sa/3.0/).

--- a/WhiteCore/Physics/BulletSPlugin/BSPrimLinkable.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSPrimLinkable.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSScene.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSScene.cs
@@ -1,5 +1,5 @@
 ﻿    /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSShapeCollection.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSShapeCollection.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSShapes.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSShapes.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSTerrainHeightmap.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSTerrainHeightmap.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSTerrainManager.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSTerrainManager.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BSTerrainMesh.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BSTerrainMesh.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/BulletSimData.cs
+++ b/WhiteCore/Physics/BulletSPlugin/BulletSimData.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://opensimulator.org/
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/BulletSPlugin/Properties/AssemblyInfo.cs
+++ b/WhiteCore/Physics/BulletSPlugin/Properties/AssemblyInfo.cs
@@ -1,4 +1,31 @@
-﻿using System.Reflection;
+﻿/*
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://virtualnexus.eu/, http://aurora-sim.org/, http://opensimulator.org/
+ * See CONTRIBUTORS.TXT for a full list of copyright holders.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyrightD
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the WhiteCore-Sim Project nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE DEVELOPERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/WhiteCore/Physics/Meshing/Properties/AssemblyInfo.cs
+++ b/WhiteCore/Physics/Meshing/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/OpenDynamicsEngine/ODEApi.cs
+++ b/WhiteCore/Physics/OpenDynamicsEngine/ODEApi.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/OpenDynamicsEngine/ODECharacter.cs
+++ b/WhiteCore/Physics/OpenDynamicsEngine/ODECharacter.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/OpenDynamicsEngine/ODEDynamics.cs
+++ b/WhiteCore/Physics/OpenDynamicsEngine/ODEDynamics.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/OpenDynamicsEngine/ODEPhysicsScene.cs
+++ b/WhiteCore/Physics/OpenDynamicsEngine/ODEPhysicsScene.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/OpenDynamicsEngine/ODEPlugin.cs
+++ b/WhiteCore/Physics/OpenDynamicsEngine/ODEPlugin.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/OpenDynamicsEngine/ODEPrim.cs
+++ b/WhiteCore/Physics/OpenDynamicsEngine/ODEPrim.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/OpenDynamicsEngine/ODERayCastRequestManager.cs
+++ b/WhiteCore/Physics/OpenDynamicsEngine/ODERayCastRequestManager.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,7 +32,6 @@ using System.Runtime.InteropServices;
 using OpenMetaverse;
 using WhiteCore.Framework.ConsoleFramework;
 using WhiteCore.Framework.Physics;
-
 
 namespace WhiteCore.Physics.OpenDynamicsEngine
 {

--- a/WhiteCore/Physics/OpenDynamicsEngine/ODESpecificAvatar.cs
+++ b/WhiteCore/Physics/OpenDynamicsEngine/ODESpecificAvatar.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/WhiteCore/Physics/OpenDynamicsEngine/Properties/AssemblyInfo.cs
+++ b/WhiteCore/Physics/OpenDynamicsEngine/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org
+ * Copyright (c) Contributors, http://whitecore-sim.org/, http://aurora-sim.org/, http://opensimulator.org/
  * See CONTRIBUTORS.TXT for a full list of copyright holders.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
README.md Fly-Man- added back the note about 0.9.2 which is not necessary and was removed during cleanup over the summer along with the Migrating to 0.9.2.txt file.

Licensing - Corrected the URLs to ensure we give proper credit to previous sources for the physics engines after reviewing both Aurora-Sim and Opensimulator   All physics engines were in both Aurora-Sim and Opensimulator (Bulletsim in Aurora was not frequently maintained but was there) and (AODE was actually the OpenDynamicsEngine used by default in Opensimulator 0.6.3 through 0.6.5