### PR TITLE
Correct using reference greythane forgot that broke build by accident

### DIFF
--- a/WhiteCore/BotManager/Bot_API.cs
+++ b/WhiteCore/BotManager/Bot_API.cs
@@ -40,7 +40,7 @@ using WhiteCore.ScriptEngine.DotNetEngine;
 using LSL_Float = WhiteCore.ScriptEngine.DotNetEngine.LSL_Types.LSLFloat;
 using LSL_Integer = WhiteCore.ScriptEngine.DotNetEngine.LSL_Types.LSLInteger;
 using LSL_Key = WhiteCore.ScriptEngine.DotNetEngine.LSL_Types.LSLString;
-using LSL_List = WhiteCore.ScriptEngine.DotNetEngine.LSL_Types.list;
+using LSL_List = WhiteCore.ScriptEngine.DotNetEngine.LSL_Types.List;
 using LSL_Rotation = WhiteCore.ScriptEngine.DotNetEngine.LSL_Types.Quaternion;
 using LSL_String = WhiteCore.ScriptEngine.DotNetEngine.LSL_Types.LSLString;
 using LSL_Vector = WhiteCore.ScriptEngine.DotNetEngine.LSL_Types.Vector3;


### PR DESCRIPTION
- When greythane fixed the LSLTypes.list by changing it to LSLTypes.List he forgot to fix the using reference in the bot manager.  This broke build so fixing that.  Build now works.

Signed-off-by: EmperorStarfinder <emperor@secondgalaxy.com>

**By submitting this pull request, I confirm the following (please check boxes, eg [X] - no spaces) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/WhiteCoreSim/WhiteCore-Dev/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/WhiteCoreSim/WhiteCore-Dev/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

10
---

- When greythane fixed the LSLTypes.list by changing it to LSLTypes.List he forgot to fix the using reference in the bot manager.  This broke build so fixing that.  Build now works.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
